### PR TITLE
リザルト時の評価毎の値を表示。引数の中の数字は削除して良い

### DIFF
--- a/Assets/Scripts/Result/ResultUIController.cs
+++ b/Assets/Scripts/Result/ResultUIController.cs
@@ -32,15 +32,18 @@ public class ResultUIController : MonoBehaviour
         {
             case Result.Bad:
                 _backGround.sprite = _backGroundSprites[3];
+                _resultValueText[0].text = "Result:Bad";
                 break;
             case Result.Good:
                 _backGround.sprite = _backGroundSprites[2];
+                _resultValueText[0].text = "Result:Good";
                 break;
             case Result.Excellent:
                 _backGround.sprite = _backGroundSprites[1];
                 break;
             case Result.Perfect:
                 _backGround.sprite = _backGroundSprites[0];
+                _resultValueText[0].text = "Result:Perfect";
                 break;
         }
     }
@@ -49,7 +52,8 @@ public class ResultUIController : MonoBehaviour
     {
         
         int count = 0;
-        //_resultValueText[0
+        yield return new WaitForSeconds(_showResultSpan);
+        _resultValueText[0].gameObject.SetActive(true);
         yield return new WaitForSeconds(_showResultSpan);
         _resultValueText[1].gameObject.SetActive(true);
         DOTween.To(() => count, (r) => count = r, /*_result.CountBad*/50, _increseTime)


### PR DESCRIPTION
59行目から70行目のコメント解除をして値を削除して変数のみにすることで評価ごとの数字が表示される
#129